### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,7 @@
 name: Git
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/openkcm/api-sdk/security/code-scanning/1](https://github.com/openkcm/api-sdk/security/code-scanning/1)

To fix the issue, add a `permissions` block to the root of the workflow. This block will explicitly define the least privileges required for the workflow to function correctly. Based on the context, the workflow likely needs read access to repository contents and possibly write access to pull requests. If additional permissions are required, they can be added after further analysis of the workflow's functionality.

The `permissions` block should be added directly under the `name` key at the top of the workflow file. This ensures that the permissions apply to all jobs in the workflow unless overridden by job-specific `permissions` blocks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
