### PR TITLE
fix: add external id and list rpc in auth service

### DIFF
--- a/proto/kms/api/cmk/registry/auth/v1/auth.pb.go
+++ b/proto/kms/api/cmk/registry/auth/v1/auth.pb.go
@@ -431,7 +431,7 @@ func (x *GetAuthResponse) GetAuth() *Auth {
 	return nil
 }
 
-type ListAuthRequest struct {
+type ListAuthsRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	TenantId      string                 `protobuf:"bytes,1,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
 	Limit         int32                  `protobuf:"varint,2,opt,name=limit,proto3" json:"limit,omitempty"` // default value is 50; max value is 1000
@@ -440,20 +440,20 @@ type ListAuthRequest struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *ListAuthRequest) Reset() {
-	*x = ListAuthRequest{}
+func (x *ListAuthsRequest) Reset() {
+	*x = ListAuthsRequest{}
 	mi := &file_kms_api_cmk_registry_auth_v1_auth_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *ListAuthRequest) String() string {
+func (x *ListAuthsRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*ListAuthRequest) ProtoMessage() {}
+func (*ListAuthsRequest) ProtoMessage() {}
 
-func (x *ListAuthRequest) ProtoReflect() protoreflect.Message {
+func (x *ListAuthsRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_kms_api_cmk_registry_auth_v1_auth_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -465,33 +465,33 @@ func (x *ListAuthRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use ListAuthRequest.ProtoReflect.Descriptor instead.
-func (*ListAuthRequest) Descriptor() ([]byte, []int) {
+// Deprecated: Use ListAuthsRequest.ProtoReflect.Descriptor instead.
+func (*ListAuthsRequest) Descriptor() ([]byte, []int) {
 	return file_kms_api_cmk_registry_auth_v1_auth_proto_rawDescGZIP(), []int{5}
 }
 
-func (x *ListAuthRequest) GetTenantId() string {
+func (x *ListAuthsRequest) GetTenantId() string {
 	if x != nil {
 		return x.TenantId
 	}
 	return ""
 }
 
-func (x *ListAuthRequest) GetLimit() int32 {
+func (x *ListAuthsRequest) GetLimit() int32 {
 	if x != nil {
 		return x.Limit
 	}
 	return 0
 }
 
-func (x *ListAuthRequest) GetNextPageToken() string {
+func (x *ListAuthsRequest) GetNextPageToken() string {
 	if x != nil {
 		return x.NextPageToken
 	}
 	return ""
 }
 
-type ListAuthResponse struct {
+type ListAuthsResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Auth          []*Auth                `protobuf:"bytes,1,rep,name=auth,proto3" json:"auth,omitempty"`
 	NextPageToken string                 `protobuf:"bytes,2,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`
@@ -499,20 +499,20 @@ type ListAuthResponse struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *ListAuthResponse) Reset() {
-	*x = ListAuthResponse{}
+func (x *ListAuthsResponse) Reset() {
+	*x = ListAuthsResponse{}
 	mi := &file_kms_api_cmk_registry_auth_v1_auth_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *ListAuthResponse) String() string {
+func (x *ListAuthsResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*ListAuthResponse) ProtoMessage() {}
+func (*ListAuthsResponse) ProtoMessage() {}
 
-func (x *ListAuthResponse) ProtoReflect() protoreflect.Message {
+func (x *ListAuthsResponse) ProtoReflect() protoreflect.Message {
 	mi := &file_kms_api_cmk_registry_auth_v1_auth_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -524,19 +524,19 @@ func (x *ListAuthResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use ListAuthResponse.ProtoReflect.Descriptor instead.
-func (*ListAuthResponse) Descriptor() ([]byte, []int) {
+// Deprecated: Use ListAuthsResponse.ProtoReflect.Descriptor instead.
+func (*ListAuthsResponse) Descriptor() ([]byte, []int) {
 	return file_kms_api_cmk_registry_auth_v1_auth_proto_rawDescGZIP(), []int{6}
 }
 
-func (x *ListAuthResponse) GetAuth() []*Auth {
+func (x *ListAuthsResponse) GetAuth() []*Auth {
 	if x != nil {
 		return x.Auth
 	}
 	return nil
 }
 
-func (x *ListAuthResponse) GetNextPageToken() string {
+func (x *ListAuthsResponse) GetNextPageToken() string {
 	if x != nil {
 		return x.NextPageToken
 	}
@@ -670,12 +670,12 @@ const file_kms_api_cmk_registry_auth_v1_auth_proto_rawDesc = "" +
 	"\vexternal_id\x18\x01 \x01(\tR\n" +
 	"externalId\"I\n" +
 	"\x0fGetAuthResponse\x126\n" +
-	"\x04auth\x18\x01 \x01(\v2\".kms.api.cmk.registry.auth.v1.AuthR\x04auth\"l\n" +
-	"\x0fListAuthRequest\x12\x1b\n" +
+	"\x04auth\x18\x01 \x01(\v2\".kms.api.cmk.registry.auth.v1.AuthR\x04auth\"m\n" +
+	"\x10ListAuthsRequest\x12\x1b\n" +
 	"\ttenant_id\x18\x01 \x01(\tR\btenantId\x12\x14\n" +
 	"\x05limit\x18\x02 \x01(\x05R\x05limit\x12&\n" +
-	"\x0fnext_page_token\x18\x03 \x01(\tR\rnextPageToken\"r\n" +
-	"\x10ListAuthResponse\x126\n" +
+	"\x0fnext_page_token\x18\x03 \x01(\tR\rnextPageToken\"s\n" +
+	"\x11ListAuthsResponse\x126\n" +
 	"\x04auth\x18\x01 \x03(\v2\".kms.api.cmk.registry.auth.v1.AuthR\x04auth\x12&\n" +
 	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"4\n" +
 	"\x11RemoveAuthRequest\x12\x1f\n" +
@@ -696,11 +696,11 @@ const file_kms_api_cmk_registry_auth_v1_auth_proto_rawDesc = "" +
 	"AuthAction\x12\x1b\n" +
 	"\x17AUTH_ACTION_UNSPECIFIED\x10\x00\x12\x1a\n" +
 	"\x16AUTH_ACTION_APPLY_AUTH\x10\x01\x12\x1b\n" +
-	"\x17AUTH_ACTION_REMOVE_AUTH\x10\x022\xc3\x03\n" +
+	"\x17AUTH_ACTION_REMOVE_AUTH\x10\x022\xc6\x03\n" +
 	"\aService\x12n\n" +
 	"\tApplyAuth\x12..kms.api.cmk.registry.auth.v1.ApplyAuthRequest\x1a/.kms.api.cmk.registry.auth.v1.ApplyAuthResponse\"\x00\x12h\n" +
-	"\aGetAuth\x12,.kms.api.cmk.registry.auth.v1.GetAuthRequest\x1a-.kms.api.cmk.registry.auth.v1.GetAuthResponse\"\x00\x12k\n" +
-	"\bListAuth\x12-.kms.api.cmk.registry.auth.v1.ListAuthRequest\x1a..kms.api.cmk.registry.auth.v1.ListAuthResponse\"\x00\x12q\n" +
+	"\aGetAuth\x12,.kms.api.cmk.registry.auth.v1.GetAuthRequest\x1a-.kms.api.cmk.registry.auth.v1.GetAuthResponse\"\x00\x12n\n" +
+	"\tListAuths\x12..kms.api.cmk.registry.auth.v1.ListAuthsRequest\x1a/.kms.api.cmk.registry.auth.v1.ListAuthsResponse\"\x00\x12q\n" +
 	"\n" +
 	"RemoveAuth\x12/.kms.api.cmk.registry.auth.v1.RemoveAuthRequest\x1a0.kms.api.cmk.registry.auth.v1.RemoveAuthResponse\"\x00B\x8a\x02\n" +
 	" com.kms.api.cmk.registry.auth.v1B\tAuthProtoP\x01ZDgithub.com/openkcm/api-sdk/proto/kms/api/cmk/registry/auth/v1;authv1\xa2\x02\x05KACRA\xaa\x02\x1cKms.Api.Cmk.Registry.Auth.V1\xca\x02\x1cKms\\Api\\Cmk\\Registry\\Auth\\V1\xe2\x02(Kms\\Api\\Cmk\\Registry\\Auth\\V1\\GPBMetadata\xea\x02!Kms::Api::Cmk::Registry::Auth::V1b\x06proto3"
@@ -727,8 +727,8 @@ var file_kms_api_cmk_registry_auth_v1_auth_proto_goTypes = []any{
 	(*ApplyAuthResponse)(nil),  // 4: kms.api.cmk.registry.auth.v1.ApplyAuthResponse
 	(*GetAuthRequest)(nil),     // 5: kms.api.cmk.registry.auth.v1.GetAuthRequest
 	(*GetAuthResponse)(nil),    // 6: kms.api.cmk.registry.auth.v1.GetAuthResponse
-	(*ListAuthRequest)(nil),    // 7: kms.api.cmk.registry.auth.v1.ListAuthRequest
-	(*ListAuthResponse)(nil),   // 8: kms.api.cmk.registry.auth.v1.ListAuthResponse
+	(*ListAuthsRequest)(nil),   // 7: kms.api.cmk.registry.auth.v1.ListAuthsRequest
+	(*ListAuthsResponse)(nil),  // 8: kms.api.cmk.registry.auth.v1.ListAuthsResponse
 	(*RemoveAuthRequest)(nil),  // 9: kms.api.cmk.registry.auth.v1.RemoveAuthRequest
 	(*RemoveAuthResponse)(nil), // 10: kms.api.cmk.registry.auth.v1.RemoveAuthResponse
 	nil,                        // 11: kms.api.cmk.registry.auth.v1.Auth.PropertiesEntry
@@ -739,14 +739,14 @@ var file_kms_api_cmk_registry_auth_v1_auth_proto_depIdxs = []int32{
 	0,  // 1: kms.api.cmk.registry.auth.v1.Auth.status:type_name -> kms.api.cmk.registry.auth.v1.AuthStatus
 	12, // 2: kms.api.cmk.registry.auth.v1.ApplyAuthRequest.properties:type_name -> kms.api.cmk.registry.auth.v1.ApplyAuthRequest.PropertiesEntry
 	2,  // 3: kms.api.cmk.registry.auth.v1.GetAuthResponse.auth:type_name -> kms.api.cmk.registry.auth.v1.Auth
-	2,  // 4: kms.api.cmk.registry.auth.v1.ListAuthResponse.auth:type_name -> kms.api.cmk.registry.auth.v1.Auth
+	2,  // 4: kms.api.cmk.registry.auth.v1.ListAuthsResponse.auth:type_name -> kms.api.cmk.registry.auth.v1.Auth
 	3,  // 5: kms.api.cmk.registry.auth.v1.Service.ApplyAuth:input_type -> kms.api.cmk.registry.auth.v1.ApplyAuthRequest
 	5,  // 6: kms.api.cmk.registry.auth.v1.Service.GetAuth:input_type -> kms.api.cmk.registry.auth.v1.GetAuthRequest
-	7,  // 7: kms.api.cmk.registry.auth.v1.Service.ListAuth:input_type -> kms.api.cmk.registry.auth.v1.ListAuthRequest
+	7,  // 7: kms.api.cmk.registry.auth.v1.Service.ListAuths:input_type -> kms.api.cmk.registry.auth.v1.ListAuthsRequest
 	9,  // 8: kms.api.cmk.registry.auth.v1.Service.RemoveAuth:input_type -> kms.api.cmk.registry.auth.v1.RemoveAuthRequest
 	4,  // 9: kms.api.cmk.registry.auth.v1.Service.ApplyAuth:output_type -> kms.api.cmk.registry.auth.v1.ApplyAuthResponse
 	6,  // 10: kms.api.cmk.registry.auth.v1.Service.GetAuth:output_type -> kms.api.cmk.registry.auth.v1.GetAuthResponse
-	8,  // 11: kms.api.cmk.registry.auth.v1.Service.ListAuth:output_type -> kms.api.cmk.registry.auth.v1.ListAuthResponse
+	8,  // 11: kms.api.cmk.registry.auth.v1.Service.ListAuths:output_type -> kms.api.cmk.registry.auth.v1.ListAuthsResponse
 	10, // 12: kms.api.cmk.registry.auth.v1.Service.RemoveAuth:output_type -> kms.api.cmk.registry.auth.v1.RemoveAuthResponse
 	9,  // [9:13] is the sub-list for method output_type
 	5,  // [5:9] is the sub-list for method input_type

--- a/proto/kms/api/cmk/registry/auth/v1/auth.pb.go
+++ b/proto/kms/api/cmk/registry/auth/v1/auth.pb.go
@@ -25,9 +25,9 @@ type AuthStatus int32
 
 const (
 	AuthStatus_AUTH_STATUS_UNSPECIFIED    AuthStatus = 0
-	AuthStatus_AUTH_STATUS_APPLIED        AuthStatus = 1
-	AuthStatus_AUTH_STATUS_APPLYING       AuthStatus = 2
-	AuthStatus_AUTH_STATUS_APPLYING_ERROR AuthStatus = 3
+	AuthStatus_AUTH_STATUS_APPLYING       AuthStatus = 1
+	AuthStatus_AUTH_STATUS_APPLYING_ERROR AuthStatus = 2
+	AuthStatus_AUTH_STATUS_APPLIED        AuthStatus = 3
 	AuthStatus_AUTH_STATUS_REMOVING       AuthStatus = 4
 	AuthStatus_AUTH_STATUS_REMOVING_ERROR AuthStatus = 5
 	AuthStatus_AUTH_STATUS_REMOVED        AuthStatus = 6
@@ -37,18 +37,18 @@ const (
 var (
 	AuthStatus_name = map[int32]string{
 		0: "AUTH_STATUS_UNSPECIFIED",
-		1: "AUTH_STATUS_APPLIED",
-		2: "AUTH_STATUS_APPLYING",
-		3: "AUTH_STATUS_APPLYING_ERROR",
+		1: "AUTH_STATUS_APPLYING",
+		2: "AUTH_STATUS_APPLYING_ERROR",
+		3: "AUTH_STATUS_APPLIED",
 		4: "AUTH_STATUS_REMOVING",
 		5: "AUTH_STATUS_REMOVING_ERROR",
 		6: "AUTH_STATUS_REMOVED",
 	}
 	AuthStatus_value = map[string]int32{
 		"AUTH_STATUS_UNSPECIFIED":    0,
-		"AUTH_STATUS_APPLIED":        1,
-		"AUTH_STATUS_APPLYING":       2,
-		"AUTH_STATUS_APPLYING_ERROR": 3,
+		"AUTH_STATUS_APPLYING":       1,
+		"AUTH_STATUS_APPLYING_ERROR": 2,
+		"AUTH_STATUS_APPLIED":        3,
 		"AUTH_STATUS_REMOVING":       4,
 		"AUTH_STATUS_REMOVING_ERROR": 5,
 		"AUTH_STATUS_REMOVED":        6,
@@ -87,6 +87,7 @@ type AuthAction int32
 const (
 	AuthAction_AUTH_ACTION_UNSPECIFIED AuthAction = 0
 	AuthAction_AUTH_ACTION_APPLY_AUTH  AuthAction = 1
+	AuthAction_AUTH_ACTION_REMOVE_AUTH AuthAction = 2
 )
 
 // Enum value maps for AuthAction.
@@ -94,10 +95,12 @@ var (
 	AuthAction_name = map[int32]string{
 		0: "AUTH_ACTION_UNSPECIFIED",
 		1: "AUTH_ACTION_APPLY_AUTH",
+		2: "AUTH_ACTION_REMOVE_AUTH",
 	}
 	AuthAction_value = map[string]int32{
 		"AUTH_ACTION_UNSPECIFIED": 0,
 		"AUTH_ACTION_APPLY_AUTH":  1,
+		"AUTH_ACTION_REMOVE_AUTH": 2,
 	}
 )
 
@@ -130,13 +133,14 @@ func (AuthAction) EnumDescriptor() ([]byte, []int) {
 
 type Auth struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	TenantId      string                 `protobuf:"bytes,1,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
-	Type          string                 `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
-	Properties    map[string]string      `protobuf:"bytes,3,rep,name=properties,proto3" json:"properties,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	Status        AuthStatus             `protobuf:"varint,4,opt,name=status,proto3,enum=kms.api.cmk.registry.auth.v1.AuthStatus" json:"status,omitempty"`
-	ErrorMessage  string                 `protobuf:"bytes,5,opt,name=error_message,json=errorMessage,proto3" json:"error_message,omitempty"`
-	UpdatedAt     string                 `protobuf:"bytes,6,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
-	CreatedAt     string                 `protobuf:"bytes,7,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	ExternalId    string                 `protobuf:"bytes,1,opt,name=external_id,json=externalId,proto3" json:"external_id,omitempty"`
+	TenantId      string                 `protobuf:"bytes,2,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
+	Type          string                 `protobuf:"bytes,3,opt,name=type,proto3" json:"type,omitempty"`
+	Properties    map[string]string      `protobuf:"bytes,4,rep,name=properties,proto3" json:"properties,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Status        AuthStatus             `protobuf:"varint,5,opt,name=status,proto3,enum=kms.api.cmk.registry.auth.v1.AuthStatus" json:"status,omitempty"`
+	ErrorMessage  string                 `protobuf:"bytes,6,opt,name=error_message,json=errorMessage,proto3" json:"error_message,omitempty"`
+	UpdatedAt     string                 `protobuf:"bytes,7,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
+	CreatedAt     string                 `protobuf:"bytes,8,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -169,6 +173,13 @@ func (x *Auth) ProtoReflect() protoreflect.Message {
 // Deprecated: Use Auth.ProtoReflect.Descriptor instead.
 func (*Auth) Descriptor() ([]byte, []int) {
 	return file_kms_api_cmk_registry_auth_v1_auth_proto_rawDescGZIP(), []int{0}
+}
+
+func (x *Auth) GetExternalId() string {
+	if x != nil {
+		return x.ExternalId
+	}
+	return ""
 }
 
 func (x *Auth) GetTenantId() string {
@@ -222,9 +233,10 @@ func (x *Auth) GetCreatedAt() string {
 
 type ApplyAuthRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	TenantId      string                 `protobuf:"bytes,1,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
-	Type          string                 `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
-	Properties    map[string]string      `protobuf:"bytes,3,rep,name=properties,proto3" json:"properties,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	ExternalId    string                 `protobuf:"bytes,1,opt,name=external_id,json=externalId,proto3" json:"external_id,omitempty"`
+	TenantId      string                 `protobuf:"bytes,2,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
+	Type          string                 `protobuf:"bytes,3,opt,name=type,proto3" json:"type,omitempty"`
+	Properties    map[string]string      `protobuf:"bytes,4,rep,name=properties,proto3" json:"properties,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -257,6 +269,13 @@ func (x *ApplyAuthRequest) ProtoReflect() protoreflect.Message {
 // Deprecated: Use ApplyAuthRequest.ProtoReflect.Descriptor instead.
 func (*ApplyAuthRequest) Descriptor() ([]byte, []int) {
 	return file_kms_api_cmk_registry_auth_v1_auth_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *ApplyAuthRequest) GetExternalId() string {
+	if x != nil {
+		return x.ExternalId
+	}
+	return ""
 }
 
 func (x *ApplyAuthRequest) GetTenantId() string {
@@ -326,7 +345,7 @@ func (x *ApplyAuthResponse) GetSuccess() bool {
 
 type GetAuthRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	TenantId      string                 `protobuf:"bytes,1,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
+	ExternalId    string                 `protobuf:"bytes,1,opt,name=external_id,json=externalId,proto3" json:"external_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -361,9 +380,9 @@ func (*GetAuthRequest) Descriptor() ([]byte, []int) {
 	return file_kms_api_cmk_registry_auth_v1_auth_proto_rawDescGZIP(), []int{3}
 }
 
-func (x *GetAuthRequest) GetTenantId() string {
+func (x *GetAuthRequest) GetExternalId() string {
 	if x != nil {
-		return x.TenantId
+		return x.ExternalId
 	}
 	return ""
 }
@@ -412,16 +431,128 @@ func (x *GetAuthResponse) GetAuth() *Auth {
 	return nil
 }
 
-type RemoveAuthRequest struct {
+type ListAuthRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	TenantId      string                 `protobuf:"bytes,1,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
+	Limit         int32                  `protobuf:"varint,2,opt,name=limit,proto3" json:"limit,omitempty"` // default value is 50; max value is 1000
+	NextPageToken string                 `protobuf:"bytes,3,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListAuthRequest) Reset() {
+	*x = ListAuthRequest{}
+	mi := &file_kms_api_cmk_registry_auth_v1_auth_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListAuthRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListAuthRequest) ProtoMessage() {}
+
+func (x *ListAuthRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_kms_api_cmk_registry_auth_v1_auth_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListAuthRequest.ProtoReflect.Descriptor instead.
+func (*ListAuthRequest) Descriptor() ([]byte, []int) {
+	return file_kms_api_cmk_registry_auth_v1_auth_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *ListAuthRequest) GetTenantId() string {
+	if x != nil {
+		return x.TenantId
+	}
+	return ""
+}
+
+func (x *ListAuthRequest) GetLimit() int32 {
+	if x != nil {
+		return x.Limit
+	}
+	return 0
+}
+
+func (x *ListAuthRequest) GetNextPageToken() string {
+	if x != nil {
+		return x.NextPageToken
+	}
+	return ""
+}
+
+type ListAuthResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Auth          []*Auth                `protobuf:"bytes,1,rep,name=auth,proto3" json:"auth,omitempty"`
+	NextPageToken string                 `protobuf:"bytes,2,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListAuthResponse) Reset() {
+	*x = ListAuthResponse{}
+	mi := &file_kms_api_cmk_registry_auth_v1_auth_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListAuthResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListAuthResponse) ProtoMessage() {}
+
+func (x *ListAuthResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_kms_api_cmk_registry_auth_v1_auth_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListAuthResponse.ProtoReflect.Descriptor instead.
+func (*ListAuthResponse) Descriptor() ([]byte, []int) {
+	return file_kms_api_cmk_registry_auth_v1_auth_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *ListAuthResponse) GetAuth() []*Auth {
+	if x != nil {
+		return x.Auth
+	}
+	return nil
+}
+
+func (x *ListAuthResponse) GetNextPageToken() string {
+	if x != nil {
+		return x.NextPageToken
+	}
+	return ""
+}
+
+type RemoveAuthRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ExternalId    string                 `protobuf:"bytes,1,opt,name=external_id,json=externalId,proto3" json:"external_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *RemoveAuthRequest) Reset() {
 	*x = RemoveAuthRequest{}
-	mi := &file_kms_api_cmk_registry_auth_v1_auth_proto_msgTypes[5]
+	mi := &file_kms_api_cmk_registry_auth_v1_auth_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -433,7 +564,7 @@ func (x *RemoveAuthRequest) String() string {
 func (*RemoveAuthRequest) ProtoMessage() {}
 
 func (x *RemoveAuthRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_kms_api_cmk_registry_auth_v1_auth_proto_msgTypes[5]
+	mi := &file_kms_api_cmk_registry_auth_v1_auth_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -446,12 +577,12 @@ func (x *RemoveAuthRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveAuthRequest.ProtoReflect.Descriptor instead.
 func (*RemoveAuthRequest) Descriptor() ([]byte, []int) {
-	return file_kms_api_cmk_registry_auth_v1_auth_proto_rawDescGZIP(), []int{5}
+	return file_kms_api_cmk_registry_auth_v1_auth_proto_rawDescGZIP(), []int{7}
 }
 
-func (x *RemoveAuthRequest) GetTenantId() string {
+func (x *RemoveAuthRequest) GetExternalId() string {
 	if x != nil {
-		return x.TenantId
+		return x.ExternalId
 	}
 	return ""
 }
@@ -465,7 +596,7 @@ type RemoveAuthResponse struct {
 
 func (x *RemoveAuthResponse) Reset() {
 	*x = RemoveAuthResponse{}
-	mi := &file_kms_api_cmk_registry_auth_v1_auth_proto_msgTypes[6]
+	mi := &file_kms_api_cmk_registry_auth_v1_auth_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -477,7 +608,7 @@ func (x *RemoveAuthResponse) String() string {
 func (*RemoveAuthResponse) ProtoMessage() {}
 
 func (x *RemoveAuthResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_kms_api_cmk_registry_auth_v1_auth_proto_msgTypes[6]
+	mi := &file_kms_api_cmk_registry_auth_v1_auth_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -490,7 +621,7 @@ func (x *RemoveAuthResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveAuthResponse.ProtoReflect.Descriptor instead.
 func (*RemoveAuthResponse) Descriptor() ([]byte, []int) {
-	return file_kms_api_cmk_registry_auth_v1_auth_proto_rawDescGZIP(), []int{6}
+	return file_kms_api_cmk_registry_auth_v1_auth_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *RemoveAuthResponse) GetSuccess() bool {
@@ -504,57 +635,72 @@ var File_kms_api_cmk_registry_auth_v1_auth_proto protoreflect.FileDescriptor
 
 const file_kms_api_cmk_registry_auth_v1_auth_proto_rawDesc = "" +
 	"\n" +
-	"'kms/api/cmk/registry/auth/v1/auth.proto\x12\x1ckms.api.cmk.registry.auth.v1\"\xef\x02\n" +
-	"\x04Auth\x12\x1b\n" +
-	"\ttenant_id\x18\x01 \x01(\tR\btenantId\x12\x12\n" +
-	"\x04type\x18\x02 \x01(\tR\x04type\x12R\n" +
+	"'kms/api/cmk/registry/auth/v1/auth.proto\x12\x1ckms.api.cmk.registry.auth.v1\"\x90\x03\n" +
+	"\x04Auth\x12\x1f\n" +
+	"\vexternal_id\x18\x01 \x01(\tR\n" +
+	"externalId\x12\x1b\n" +
+	"\ttenant_id\x18\x02 \x01(\tR\btenantId\x12\x12\n" +
+	"\x04type\x18\x03 \x01(\tR\x04type\x12R\n" +
 	"\n" +
-	"properties\x18\x03 \x03(\v22.kms.api.cmk.registry.auth.v1.Auth.PropertiesEntryR\n" +
+	"properties\x18\x04 \x03(\v22.kms.api.cmk.registry.auth.v1.Auth.PropertiesEntryR\n" +
 	"properties\x12@\n" +
-	"\x06status\x18\x04 \x01(\x0e2(.kms.api.cmk.registry.auth.v1.AuthStatusR\x06status\x12#\n" +
-	"\rerror_message\x18\x05 \x01(\tR\ferrorMessage\x12\x1d\n" +
+	"\x06status\x18\x05 \x01(\x0e2(.kms.api.cmk.registry.auth.v1.AuthStatusR\x06status\x12#\n" +
+	"\rerror_message\x18\x06 \x01(\tR\ferrorMessage\x12\x1d\n" +
 	"\n" +
-	"updated_at\x18\x06 \x01(\tR\tupdatedAt\x12\x1d\n" +
+	"updated_at\x18\a \x01(\tR\tupdatedAt\x12\x1d\n" +
 	"\n" +
-	"created_at\x18\a \x01(\tR\tcreatedAt\x1a=\n" +
+	"created_at\x18\b \x01(\tR\tcreatedAt\x1a=\n" +
 	"\x0fPropertiesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xe2\x01\n" +
-	"\x10ApplyAuthRequest\x12\x1b\n" +
-	"\ttenant_id\x18\x01 \x01(\tR\btenantId\x12\x12\n" +
-	"\x04type\x18\x02 \x01(\tR\x04type\x12^\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x83\x02\n" +
+	"\x10ApplyAuthRequest\x12\x1f\n" +
+	"\vexternal_id\x18\x01 \x01(\tR\n" +
+	"externalId\x12\x1b\n" +
+	"\ttenant_id\x18\x02 \x01(\tR\btenantId\x12\x12\n" +
+	"\x04type\x18\x03 \x01(\tR\x04type\x12^\n" +
 	"\n" +
-	"properties\x18\x03 \x03(\v2>.kms.api.cmk.registry.auth.v1.ApplyAuthRequest.PropertiesEntryR\n" +
+	"properties\x18\x04 \x03(\v2>.kms.api.cmk.registry.auth.v1.ApplyAuthRequest.PropertiesEntryR\n" +
 	"properties\x1a=\n" +
 	"\x0fPropertiesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"-\n" +
 	"\x11ApplyAuthResponse\x12\x18\n" +
-	"\asuccess\x18\x01 \x01(\bR\asuccess\"-\n" +
-	"\x0eGetAuthRequest\x12\x1b\n" +
-	"\ttenant_id\x18\x01 \x01(\tR\btenantId\"I\n" +
+	"\asuccess\x18\x01 \x01(\bR\asuccess\"1\n" +
+	"\x0eGetAuthRequest\x12\x1f\n" +
+	"\vexternal_id\x18\x01 \x01(\tR\n" +
+	"externalId\"I\n" +
 	"\x0fGetAuthResponse\x126\n" +
-	"\x04auth\x18\x01 \x01(\v2\".kms.api.cmk.registry.auth.v1.AuthR\x04auth\"0\n" +
-	"\x11RemoveAuthRequest\x12\x1b\n" +
-	"\ttenant_id\x18\x01 \x01(\tR\btenantId\".\n" +
+	"\x04auth\x18\x01 \x01(\v2\".kms.api.cmk.registry.auth.v1.AuthR\x04auth\"l\n" +
+	"\x0fListAuthRequest\x12\x1b\n" +
+	"\ttenant_id\x18\x01 \x01(\tR\btenantId\x12\x14\n" +
+	"\x05limit\x18\x02 \x01(\x05R\x05limit\x12&\n" +
+	"\x0fnext_page_token\x18\x03 \x01(\tR\rnextPageToken\"r\n" +
+	"\x10ListAuthResponse\x126\n" +
+	"\x04auth\x18\x01 \x03(\v2\".kms.api.cmk.registry.auth.v1.AuthR\x04auth\x12&\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"4\n" +
+	"\x11RemoveAuthRequest\x12\x1f\n" +
+	"\vexternal_id\x18\x01 \x01(\tR\n" +
+	"externalId\".\n" +
 	"\x12RemoveAuthResponse\x12\x18\n" +
 	"\asuccess\x18\x01 \x01(\bR\asuccess*\xcf\x01\n" +
 	"\n" +
 	"AuthStatus\x12\x1b\n" +
-	"\x17AUTH_STATUS_UNSPECIFIED\x10\x00\x12\x17\n" +
-	"\x13AUTH_STATUS_APPLIED\x10\x01\x12\x18\n" +
-	"\x14AUTH_STATUS_APPLYING\x10\x02\x12\x1e\n" +
-	"\x1aAUTH_STATUS_APPLYING_ERROR\x10\x03\x12\x18\n" +
+	"\x17AUTH_STATUS_UNSPECIFIED\x10\x00\x12\x18\n" +
+	"\x14AUTH_STATUS_APPLYING\x10\x01\x12\x1e\n" +
+	"\x1aAUTH_STATUS_APPLYING_ERROR\x10\x02\x12\x17\n" +
+	"\x13AUTH_STATUS_APPLIED\x10\x03\x12\x18\n" +
 	"\x14AUTH_STATUS_REMOVING\x10\x04\x12\x1e\n" +
 	"\x1aAUTH_STATUS_REMOVING_ERROR\x10\x05\x12\x17\n" +
-	"\x13AUTH_STATUS_REMOVED\x10\x06*E\n" +
+	"\x13AUTH_STATUS_REMOVED\x10\x06*b\n" +
 	"\n" +
 	"AuthAction\x12\x1b\n" +
 	"\x17AUTH_ACTION_UNSPECIFIED\x10\x00\x12\x1a\n" +
-	"\x16AUTH_ACTION_APPLY_AUTH\x10\x012\xd6\x02\n" +
+	"\x16AUTH_ACTION_APPLY_AUTH\x10\x01\x12\x1b\n" +
+	"\x17AUTH_ACTION_REMOVE_AUTH\x10\x022\xc3\x03\n" +
 	"\aService\x12n\n" +
 	"\tApplyAuth\x12..kms.api.cmk.registry.auth.v1.ApplyAuthRequest\x1a/.kms.api.cmk.registry.auth.v1.ApplyAuthResponse\"\x00\x12h\n" +
-	"\aGetAuth\x12,.kms.api.cmk.registry.auth.v1.GetAuthRequest\x1a-.kms.api.cmk.registry.auth.v1.GetAuthResponse\"\x00\x12q\n" +
+	"\aGetAuth\x12,.kms.api.cmk.registry.auth.v1.GetAuthRequest\x1a-.kms.api.cmk.registry.auth.v1.GetAuthResponse\"\x00\x12k\n" +
+	"\bListAuth\x12-.kms.api.cmk.registry.auth.v1.ListAuthRequest\x1a..kms.api.cmk.registry.auth.v1.ListAuthResponse\"\x00\x12q\n" +
 	"\n" +
 	"RemoveAuth\x12/.kms.api.cmk.registry.auth.v1.RemoveAuthRequest\x1a0.kms.api.cmk.registry.auth.v1.RemoveAuthResponse\"\x00B\x8a\x02\n" +
 	" com.kms.api.cmk.registry.auth.v1B\tAuthProtoP\x01ZDgithub.com/openkcm/api-sdk/proto/kms/api/cmk/registry/auth/v1;authv1\xa2\x02\x05KACRA\xaa\x02\x1cKms.Api.Cmk.Registry.Auth.V1\xca\x02\x1cKms\\Api\\Cmk\\Registry\\Auth\\V1\xe2\x02(Kms\\Api\\Cmk\\Registry\\Auth\\V1\\GPBMetadata\xea\x02!Kms::Api::Cmk::Registry::Auth::V1b\x06proto3"
@@ -572,7 +718,7 @@ func file_kms_api_cmk_registry_auth_v1_auth_proto_rawDescGZIP() []byte {
 }
 
 var file_kms_api_cmk_registry_auth_v1_auth_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_kms_api_cmk_registry_auth_v1_auth_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
+var file_kms_api_cmk_registry_auth_v1_auth_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
 var file_kms_api_cmk_registry_auth_v1_auth_proto_goTypes = []any{
 	(AuthStatus)(0),            // 0: kms.api.cmk.registry.auth.v1.AuthStatus
 	(AuthAction)(0),            // 1: kms.api.cmk.registry.auth.v1.AuthAction
@@ -581,27 +727,32 @@ var file_kms_api_cmk_registry_auth_v1_auth_proto_goTypes = []any{
 	(*ApplyAuthResponse)(nil),  // 4: kms.api.cmk.registry.auth.v1.ApplyAuthResponse
 	(*GetAuthRequest)(nil),     // 5: kms.api.cmk.registry.auth.v1.GetAuthRequest
 	(*GetAuthResponse)(nil),    // 6: kms.api.cmk.registry.auth.v1.GetAuthResponse
-	(*RemoveAuthRequest)(nil),  // 7: kms.api.cmk.registry.auth.v1.RemoveAuthRequest
-	(*RemoveAuthResponse)(nil), // 8: kms.api.cmk.registry.auth.v1.RemoveAuthResponse
-	nil,                        // 9: kms.api.cmk.registry.auth.v1.Auth.PropertiesEntry
-	nil,                        // 10: kms.api.cmk.registry.auth.v1.ApplyAuthRequest.PropertiesEntry
+	(*ListAuthRequest)(nil),    // 7: kms.api.cmk.registry.auth.v1.ListAuthRequest
+	(*ListAuthResponse)(nil),   // 8: kms.api.cmk.registry.auth.v1.ListAuthResponse
+	(*RemoveAuthRequest)(nil),  // 9: kms.api.cmk.registry.auth.v1.RemoveAuthRequest
+	(*RemoveAuthResponse)(nil), // 10: kms.api.cmk.registry.auth.v1.RemoveAuthResponse
+	nil,                        // 11: kms.api.cmk.registry.auth.v1.Auth.PropertiesEntry
+	nil,                        // 12: kms.api.cmk.registry.auth.v1.ApplyAuthRequest.PropertiesEntry
 }
 var file_kms_api_cmk_registry_auth_v1_auth_proto_depIdxs = []int32{
-	9,  // 0: kms.api.cmk.registry.auth.v1.Auth.properties:type_name -> kms.api.cmk.registry.auth.v1.Auth.PropertiesEntry
+	11, // 0: kms.api.cmk.registry.auth.v1.Auth.properties:type_name -> kms.api.cmk.registry.auth.v1.Auth.PropertiesEntry
 	0,  // 1: kms.api.cmk.registry.auth.v1.Auth.status:type_name -> kms.api.cmk.registry.auth.v1.AuthStatus
-	10, // 2: kms.api.cmk.registry.auth.v1.ApplyAuthRequest.properties:type_name -> kms.api.cmk.registry.auth.v1.ApplyAuthRequest.PropertiesEntry
+	12, // 2: kms.api.cmk.registry.auth.v1.ApplyAuthRequest.properties:type_name -> kms.api.cmk.registry.auth.v1.ApplyAuthRequest.PropertiesEntry
 	2,  // 3: kms.api.cmk.registry.auth.v1.GetAuthResponse.auth:type_name -> kms.api.cmk.registry.auth.v1.Auth
-	3,  // 4: kms.api.cmk.registry.auth.v1.Service.ApplyAuth:input_type -> kms.api.cmk.registry.auth.v1.ApplyAuthRequest
-	5,  // 5: kms.api.cmk.registry.auth.v1.Service.GetAuth:input_type -> kms.api.cmk.registry.auth.v1.GetAuthRequest
-	7,  // 6: kms.api.cmk.registry.auth.v1.Service.RemoveAuth:input_type -> kms.api.cmk.registry.auth.v1.RemoveAuthRequest
-	4,  // 7: kms.api.cmk.registry.auth.v1.Service.ApplyAuth:output_type -> kms.api.cmk.registry.auth.v1.ApplyAuthResponse
-	6,  // 8: kms.api.cmk.registry.auth.v1.Service.GetAuth:output_type -> kms.api.cmk.registry.auth.v1.GetAuthResponse
-	8,  // 9: kms.api.cmk.registry.auth.v1.Service.RemoveAuth:output_type -> kms.api.cmk.registry.auth.v1.RemoveAuthResponse
-	7,  // [7:10] is the sub-list for method output_type
-	4,  // [4:7] is the sub-list for method input_type
-	4,  // [4:4] is the sub-list for extension type_name
-	4,  // [4:4] is the sub-list for extension extendee
-	0,  // [0:4] is the sub-list for field type_name
+	2,  // 4: kms.api.cmk.registry.auth.v1.ListAuthResponse.auth:type_name -> kms.api.cmk.registry.auth.v1.Auth
+	3,  // 5: kms.api.cmk.registry.auth.v1.Service.ApplyAuth:input_type -> kms.api.cmk.registry.auth.v1.ApplyAuthRequest
+	5,  // 6: kms.api.cmk.registry.auth.v1.Service.GetAuth:input_type -> kms.api.cmk.registry.auth.v1.GetAuthRequest
+	7,  // 7: kms.api.cmk.registry.auth.v1.Service.ListAuth:input_type -> kms.api.cmk.registry.auth.v1.ListAuthRequest
+	9,  // 8: kms.api.cmk.registry.auth.v1.Service.RemoveAuth:input_type -> kms.api.cmk.registry.auth.v1.RemoveAuthRequest
+	4,  // 9: kms.api.cmk.registry.auth.v1.Service.ApplyAuth:output_type -> kms.api.cmk.registry.auth.v1.ApplyAuthResponse
+	6,  // 10: kms.api.cmk.registry.auth.v1.Service.GetAuth:output_type -> kms.api.cmk.registry.auth.v1.GetAuthResponse
+	8,  // 11: kms.api.cmk.registry.auth.v1.Service.ListAuth:output_type -> kms.api.cmk.registry.auth.v1.ListAuthResponse
+	10, // 12: kms.api.cmk.registry.auth.v1.Service.RemoveAuth:output_type -> kms.api.cmk.registry.auth.v1.RemoveAuthResponse
+	9,  // [9:13] is the sub-list for method output_type
+	5,  // [5:9] is the sub-list for method input_type
+	5,  // [5:5] is the sub-list for extension type_name
+	5,  // [5:5] is the sub-list for extension extendee
+	0,  // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_kms_api_cmk_registry_auth_v1_auth_proto_init() }
@@ -615,7 +766,7 @@ func file_kms_api_cmk_registry_auth_v1_auth_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_kms_api_cmk_registry_auth_v1_auth_proto_rawDesc), len(file_kms_api_cmk_registry_auth_v1_auth_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   9,
+			NumMessages:   11,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/kms/api/cmk/registry/auth/v1/auth.pb.validate.go
+++ b/proto/kms/api/cmk/registry/auth/v1/auth.pb.validate.go
@@ -56,6 +56,8 @@ func (m *Auth) validate(all bool) error {
 
 	var errors []error
 
+	// no validation rules for ExternalId
+
 	// no validation rules for TenantId
 
 	// no validation rules for Type
@@ -168,6 +170,8 @@ func (m *ApplyAuthRequest) validate(all bool) error {
 	}
 
 	var errors []error
+
+	// no validation rules for ExternalId
 
 	// no validation rules for TenantId
 
@@ -379,7 +383,7 @@ func (m *GetAuthRequest) validate(all bool) error {
 
 	var errors []error
 
-	// no validation rules for TenantId
+	// no validation rules for ExternalId
 
 	if len(errors) > 0 {
 		return GetAuthRequestMultiError(errors)
@@ -588,6 +592,248 @@ var _ interface {
 	ErrorName() string
 } = GetAuthResponseValidationError{}
 
+// Validate checks the field values on ListAuthRequest with the rules defined
+// in the proto definition for this message. If any rules are violated, the
+// first error encountered is returned, or nil if there are no violations.
+func (m *ListAuthRequest) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on ListAuthRequest with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// ListAuthRequestMultiError, or nil if none found.
+func (m *ListAuthRequest) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *ListAuthRequest) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	// no validation rules for TenantId
+
+	// no validation rules for Limit
+
+	// no validation rules for NextPageToken
+
+	if len(errors) > 0 {
+		return ListAuthRequestMultiError(errors)
+	}
+
+	return nil
+}
+
+// ListAuthRequestMultiError is an error wrapping multiple validation errors
+// returned by ListAuthRequest.ValidateAll() if the designated constraints
+// aren't met.
+type ListAuthRequestMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m ListAuthRequestMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m ListAuthRequestMultiError) AllErrors() []error { return m }
+
+// ListAuthRequestValidationError is the validation error returned by
+// ListAuthRequest.Validate if the designated constraints aren't met.
+type ListAuthRequestValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e ListAuthRequestValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e ListAuthRequestValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e ListAuthRequestValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e ListAuthRequestValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e ListAuthRequestValidationError) ErrorName() string { return "ListAuthRequestValidationError" }
+
+// Error satisfies the builtin error interface
+func (e ListAuthRequestValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sListAuthRequest.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = ListAuthRequestValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = ListAuthRequestValidationError{}
+
+// Validate checks the field values on ListAuthResponse with the rules defined
+// in the proto definition for this message. If any rules are violated, the
+// first error encountered is returned, or nil if there are no violations.
+func (m *ListAuthResponse) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on ListAuthResponse with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// ListAuthResponseMultiError, or nil if none found.
+func (m *ListAuthResponse) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *ListAuthResponse) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	for idx, item := range m.GetAuth() {
+		_, _ = idx, item
+
+		if all {
+			switch v := interface{}(item).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, ListAuthResponseValidationError{
+						field:  fmt.Sprintf("Auth[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, ListAuthResponseValidationError{
+						field:  fmt.Sprintf("Auth[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(item).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return ListAuthResponseValidationError{
+					field:  fmt.Sprintf("Auth[%v]", idx),
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
+	}
+
+	// no validation rules for NextPageToken
+
+	if len(errors) > 0 {
+		return ListAuthResponseMultiError(errors)
+	}
+
+	return nil
+}
+
+// ListAuthResponseMultiError is an error wrapping multiple validation errors
+// returned by ListAuthResponse.ValidateAll() if the designated constraints
+// aren't met.
+type ListAuthResponseMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m ListAuthResponseMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m ListAuthResponseMultiError) AllErrors() []error { return m }
+
+// ListAuthResponseValidationError is the validation error returned by
+// ListAuthResponse.Validate if the designated constraints aren't met.
+type ListAuthResponseValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e ListAuthResponseValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e ListAuthResponseValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e ListAuthResponseValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e ListAuthResponseValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e ListAuthResponseValidationError) ErrorName() string { return "ListAuthResponseValidationError" }
+
+// Error satisfies the builtin error interface
+func (e ListAuthResponseValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sListAuthResponse.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = ListAuthResponseValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = ListAuthResponseValidationError{}
+
 // Validate checks the field values on RemoveAuthRequest with the rules defined
 // in the proto definition for this message. If any rules are violated, the
 // first error encountered is returned, or nil if there are no violations.
@@ -610,7 +856,7 @@ func (m *RemoveAuthRequest) validate(all bool) error {
 
 	var errors []error
 
-	// no validation rules for TenantId
+	// no validation rules for ExternalId
 
 	if len(errors) > 0 {
 		return RemoveAuthRequestMultiError(errors)

--- a/proto/kms/api/cmk/registry/auth/v1/auth.pb.validate.go
+++ b/proto/kms/api/cmk/registry/auth/v1/auth.pb.validate.go
@@ -592,22 +592,22 @@ var _ interface {
 	ErrorName() string
 } = GetAuthResponseValidationError{}
 
-// Validate checks the field values on ListAuthRequest with the rules defined
+// Validate checks the field values on ListAuthsRequest with the rules defined
 // in the proto definition for this message. If any rules are violated, the
 // first error encountered is returned, or nil if there are no violations.
-func (m *ListAuthRequest) Validate() error {
+func (m *ListAuthsRequest) Validate() error {
 	return m.validate(false)
 }
 
-// ValidateAll checks the field values on ListAuthRequest with the rules
+// ValidateAll checks the field values on ListAuthsRequest with the rules
 // defined in the proto definition for this message. If any rules are
 // violated, the result is a list of violation errors wrapped in
-// ListAuthRequestMultiError, or nil if none found.
-func (m *ListAuthRequest) ValidateAll() error {
+// ListAuthsRequestMultiError, or nil if none found.
+func (m *ListAuthsRequest) ValidateAll() error {
 	return m.validate(true)
 }
 
-func (m *ListAuthRequest) validate(all bool) error {
+func (m *ListAuthsRequest) validate(all bool) error {
 	if m == nil {
 		return nil
 	}
@@ -621,19 +621,19 @@ func (m *ListAuthRequest) validate(all bool) error {
 	// no validation rules for NextPageToken
 
 	if len(errors) > 0 {
-		return ListAuthRequestMultiError(errors)
+		return ListAuthsRequestMultiError(errors)
 	}
 
 	return nil
 }
 
-// ListAuthRequestMultiError is an error wrapping multiple validation errors
-// returned by ListAuthRequest.ValidateAll() if the designated constraints
+// ListAuthsRequestMultiError is an error wrapping multiple validation errors
+// returned by ListAuthsRequest.ValidateAll() if the designated constraints
 // aren't met.
-type ListAuthRequestMultiError []error
+type ListAuthsRequestMultiError []error
 
 // Error returns a concatenation of all the error messages it wraps.
-func (m ListAuthRequestMultiError) Error() string {
+func (m ListAuthsRequestMultiError) Error() string {
 	msgs := make([]string, 0, len(m))
 	for _, err := range m {
 		msgs = append(msgs, err.Error())
@@ -642,11 +642,11 @@ func (m ListAuthRequestMultiError) Error() string {
 }
 
 // AllErrors returns a list of validation violation errors.
-func (m ListAuthRequestMultiError) AllErrors() []error { return m }
+func (m ListAuthsRequestMultiError) AllErrors() []error { return m }
 
-// ListAuthRequestValidationError is the validation error returned by
-// ListAuthRequest.Validate if the designated constraints aren't met.
-type ListAuthRequestValidationError struct {
+// ListAuthsRequestValidationError is the validation error returned by
+// ListAuthsRequest.Validate if the designated constraints aren't met.
+type ListAuthsRequestValidationError struct {
 	field  string
 	reason string
 	cause  error
@@ -654,22 +654,22 @@ type ListAuthRequestValidationError struct {
 }
 
 // Field function returns field value.
-func (e ListAuthRequestValidationError) Field() string { return e.field }
+func (e ListAuthsRequestValidationError) Field() string { return e.field }
 
 // Reason function returns reason value.
-func (e ListAuthRequestValidationError) Reason() string { return e.reason }
+func (e ListAuthsRequestValidationError) Reason() string { return e.reason }
 
 // Cause function returns cause value.
-func (e ListAuthRequestValidationError) Cause() error { return e.cause }
+func (e ListAuthsRequestValidationError) Cause() error { return e.cause }
 
 // Key function returns key value.
-func (e ListAuthRequestValidationError) Key() bool { return e.key }
+func (e ListAuthsRequestValidationError) Key() bool { return e.key }
 
 // ErrorName returns error name.
-func (e ListAuthRequestValidationError) ErrorName() string { return "ListAuthRequestValidationError" }
+func (e ListAuthsRequestValidationError) ErrorName() string { return "ListAuthsRequestValidationError" }
 
 // Error satisfies the builtin error interface
-func (e ListAuthRequestValidationError) Error() string {
+func (e ListAuthsRequestValidationError) Error() string {
 	cause := ""
 	if e.cause != nil {
 		cause = fmt.Sprintf(" | caused by: %v", e.cause)
@@ -681,14 +681,14 @@ func (e ListAuthRequestValidationError) Error() string {
 	}
 
 	return fmt.Sprintf(
-		"invalid %sListAuthRequest.%s: %s%s",
+		"invalid %sListAuthsRequest.%s: %s%s",
 		key,
 		e.field,
 		e.reason,
 		cause)
 }
 
-var _ error = ListAuthRequestValidationError{}
+var _ error = ListAuthsRequestValidationError{}
 
 var _ interface {
 	Field() string
@@ -696,24 +696,24 @@ var _ interface {
 	Key() bool
 	Cause() error
 	ErrorName() string
-} = ListAuthRequestValidationError{}
+} = ListAuthsRequestValidationError{}
 
-// Validate checks the field values on ListAuthResponse with the rules defined
+// Validate checks the field values on ListAuthsResponse with the rules defined
 // in the proto definition for this message. If any rules are violated, the
 // first error encountered is returned, or nil if there are no violations.
-func (m *ListAuthResponse) Validate() error {
+func (m *ListAuthsResponse) Validate() error {
 	return m.validate(false)
 }
 
-// ValidateAll checks the field values on ListAuthResponse with the rules
+// ValidateAll checks the field values on ListAuthsResponse with the rules
 // defined in the proto definition for this message. If any rules are
 // violated, the result is a list of violation errors wrapped in
-// ListAuthResponseMultiError, or nil if none found.
-func (m *ListAuthResponse) ValidateAll() error {
+// ListAuthsResponseMultiError, or nil if none found.
+func (m *ListAuthsResponse) ValidateAll() error {
 	return m.validate(true)
 }
 
-func (m *ListAuthResponse) validate(all bool) error {
+func (m *ListAuthsResponse) validate(all bool) error {
 	if m == nil {
 		return nil
 	}
@@ -727,7 +727,7 @@ func (m *ListAuthResponse) validate(all bool) error {
 			switch v := interface{}(item).(type) {
 			case interface{ ValidateAll() error }:
 				if err := v.ValidateAll(); err != nil {
-					errors = append(errors, ListAuthResponseValidationError{
+					errors = append(errors, ListAuthsResponseValidationError{
 						field:  fmt.Sprintf("Auth[%v]", idx),
 						reason: "embedded message failed validation",
 						cause:  err,
@@ -735,7 +735,7 @@ func (m *ListAuthResponse) validate(all bool) error {
 				}
 			case interface{ Validate() error }:
 				if err := v.Validate(); err != nil {
-					errors = append(errors, ListAuthResponseValidationError{
+					errors = append(errors, ListAuthsResponseValidationError{
 						field:  fmt.Sprintf("Auth[%v]", idx),
 						reason: "embedded message failed validation",
 						cause:  err,
@@ -744,7 +744,7 @@ func (m *ListAuthResponse) validate(all bool) error {
 			}
 		} else if v, ok := interface{}(item).(interface{ Validate() error }); ok {
 			if err := v.Validate(); err != nil {
-				return ListAuthResponseValidationError{
+				return ListAuthsResponseValidationError{
 					field:  fmt.Sprintf("Auth[%v]", idx),
 					reason: "embedded message failed validation",
 					cause:  err,
@@ -757,19 +757,19 @@ func (m *ListAuthResponse) validate(all bool) error {
 	// no validation rules for NextPageToken
 
 	if len(errors) > 0 {
-		return ListAuthResponseMultiError(errors)
+		return ListAuthsResponseMultiError(errors)
 	}
 
 	return nil
 }
 
-// ListAuthResponseMultiError is an error wrapping multiple validation errors
-// returned by ListAuthResponse.ValidateAll() if the designated constraints
+// ListAuthsResponseMultiError is an error wrapping multiple validation errors
+// returned by ListAuthsResponse.ValidateAll() if the designated constraints
 // aren't met.
-type ListAuthResponseMultiError []error
+type ListAuthsResponseMultiError []error
 
 // Error returns a concatenation of all the error messages it wraps.
-func (m ListAuthResponseMultiError) Error() string {
+func (m ListAuthsResponseMultiError) Error() string {
 	msgs := make([]string, 0, len(m))
 	for _, err := range m {
 		msgs = append(msgs, err.Error())
@@ -778,11 +778,11 @@ func (m ListAuthResponseMultiError) Error() string {
 }
 
 // AllErrors returns a list of validation violation errors.
-func (m ListAuthResponseMultiError) AllErrors() []error { return m }
+func (m ListAuthsResponseMultiError) AllErrors() []error { return m }
 
-// ListAuthResponseValidationError is the validation error returned by
-// ListAuthResponse.Validate if the designated constraints aren't met.
-type ListAuthResponseValidationError struct {
+// ListAuthsResponseValidationError is the validation error returned by
+// ListAuthsResponse.Validate if the designated constraints aren't met.
+type ListAuthsResponseValidationError struct {
 	field  string
 	reason string
 	cause  error
@@ -790,22 +790,24 @@ type ListAuthResponseValidationError struct {
 }
 
 // Field function returns field value.
-func (e ListAuthResponseValidationError) Field() string { return e.field }
+func (e ListAuthsResponseValidationError) Field() string { return e.field }
 
 // Reason function returns reason value.
-func (e ListAuthResponseValidationError) Reason() string { return e.reason }
+func (e ListAuthsResponseValidationError) Reason() string { return e.reason }
 
 // Cause function returns cause value.
-func (e ListAuthResponseValidationError) Cause() error { return e.cause }
+func (e ListAuthsResponseValidationError) Cause() error { return e.cause }
 
 // Key function returns key value.
-func (e ListAuthResponseValidationError) Key() bool { return e.key }
+func (e ListAuthsResponseValidationError) Key() bool { return e.key }
 
 // ErrorName returns error name.
-func (e ListAuthResponseValidationError) ErrorName() string { return "ListAuthResponseValidationError" }
+func (e ListAuthsResponseValidationError) ErrorName() string {
+	return "ListAuthsResponseValidationError"
+}
 
 // Error satisfies the builtin error interface
-func (e ListAuthResponseValidationError) Error() string {
+func (e ListAuthsResponseValidationError) Error() string {
 	cause := ""
 	if e.cause != nil {
 		cause = fmt.Sprintf(" | caused by: %v", e.cause)
@@ -817,14 +819,14 @@ func (e ListAuthResponseValidationError) Error() string {
 	}
 
 	return fmt.Sprintf(
-		"invalid %sListAuthResponse.%s: %s%s",
+		"invalid %sListAuthsResponse.%s: %s%s",
 		key,
 		e.field,
 		e.reason,
 		cause)
 }
 
-var _ error = ListAuthResponseValidationError{}
+var _ error = ListAuthsResponseValidationError{}
 
 var _ interface {
 	Field() string
@@ -832,7 +834,7 @@ var _ interface {
 	Key() bool
 	Cause() error
 	ErrorName() string
-} = ListAuthResponseValidationError{}
+} = ListAuthsResponseValidationError{}
 
 // Validate checks the field values on RemoveAuthRequest with the rules defined
 // in the proto definition for this message. If any rules are violated, the

--- a/proto/kms/api/cmk/registry/auth/v1/auth.proto
+++ b/proto/kms/api/cmk/registry/auth/v1/auth.proto
@@ -5,23 +5,26 @@ package kms.api.cmk.registry.auth.v1;
 service Service {
   rpc ApplyAuth(ApplyAuthRequest) returns (ApplyAuthResponse) {}
   rpc GetAuth(GetAuthRequest) returns (GetAuthResponse) {}
+  rpc ListAuth(ListAuthRequest) returns (ListAuthResponse) {}
   rpc RemoveAuth(RemoveAuthRequest) returns (RemoveAuthResponse) {}
 }
 
 message Auth {
-  string tenant_id = 1;
-  string type = 2;
-  map<string, string> properties = 3;
-  AuthStatus status = 4;
-  string error_message = 5;
-  string updated_at = 6;
-  string created_at = 7;
+  string external_id = 1;
+  string tenant_id = 2;
+  string type = 3;
+  map<string, string> properties = 4;
+  AuthStatus status = 5;
+  string error_message = 6;
+  string updated_at = 7;
+  string created_at = 8;
 }
 
 message ApplyAuthRequest {
-  string tenant_id = 1;
-  string type = 2;
-  map<string, string> properties = 3;
+  string external_id = 1;
+  string tenant_id = 2;
+  string type = 3;
+  map<string, string> properties = 4;
 }
 
 message ApplyAuthResponse {
@@ -29,15 +32,28 @@ message ApplyAuthResponse {
 }
 
 message GetAuthRequest {
-  string tenant_id = 1;
+  string external_id = 1;
 }
 
 message GetAuthResponse {
   Auth auth = 1;
 }
 
-message RemoveAuthRequest {
+message ListAuthRequest {
   string tenant_id = 1;
+
+  int32 limit = 2; // default value is 50; max value is 1000
+  string next_page_token = 3;
+}
+
+message ListAuthResponse {
+  repeated Auth auth = 1;
+
+  string next_page_token = 2;
+}
+
+message RemoveAuthRequest {
+  string external_id = 1;
 }
 
 message RemoveAuthResponse {
@@ -46,9 +62,9 @@ message RemoveAuthResponse {
 
 enum AuthStatus {
   AUTH_STATUS_UNSPECIFIED = 0;
-  AUTH_STATUS_APPLIED = 1;
-  AUTH_STATUS_APPLYING = 2;
-  AUTH_STATUS_APPLYING_ERROR = 3;
+  AUTH_STATUS_APPLYING = 1;
+  AUTH_STATUS_APPLYING_ERROR = 2;
+  AUTH_STATUS_APPLIED = 3;
   AUTH_STATUS_REMOVING = 4;
   AUTH_STATUS_REMOVING_ERROR = 5;
   AUTH_STATUS_REMOVED = 6;
@@ -57,4 +73,5 @@ enum AuthStatus {
 enum AuthAction {
   AUTH_ACTION_UNSPECIFIED = 0;
   AUTH_ACTION_APPLY_AUTH = 1;
+  AUTH_ACTION_REMOVE_AUTH = 2;
 }

--- a/proto/kms/api/cmk/registry/auth/v1/auth.proto
+++ b/proto/kms/api/cmk/registry/auth/v1/auth.proto
@@ -5,7 +5,7 @@ package kms.api.cmk.registry.auth.v1;
 service Service {
   rpc ApplyAuth(ApplyAuthRequest) returns (ApplyAuthResponse) {}
   rpc GetAuth(GetAuthRequest) returns (GetAuthResponse) {}
-  rpc ListAuth(ListAuthRequest) returns (ListAuthResponse) {}
+  rpc ListAuths(ListAuthsRequest) returns (ListAuthsResponse) {}
   rpc RemoveAuth(RemoveAuthRequest) returns (RemoveAuthResponse) {}
 }
 
@@ -39,14 +39,14 @@ message GetAuthResponse {
   Auth auth = 1;
 }
 
-message ListAuthRequest {
+message ListAuthsRequest {
   string tenant_id = 1;
 
   int32 limit = 2; // default value is 50; max value is 1000
   string next_page_token = 3;
 }
 
-message ListAuthResponse {
+message ListAuthsResponse {
   repeated Auth auth = 1;
 
   string next_page_token = 2;

--- a/proto/kms/api/cmk/registry/auth/v1/auth_grpc.pb.go
+++ b/proto/kms/api/cmk/registry/auth/v1/auth_grpc.pb.go
@@ -21,7 +21,7 @@ const _ = grpc.SupportPackageIsVersion9
 const (
 	Service_ApplyAuth_FullMethodName  = "/kms.api.cmk.registry.auth.v1.Service/ApplyAuth"
 	Service_GetAuth_FullMethodName    = "/kms.api.cmk.registry.auth.v1.Service/GetAuth"
-	Service_ListAuth_FullMethodName   = "/kms.api.cmk.registry.auth.v1.Service/ListAuth"
+	Service_ListAuths_FullMethodName  = "/kms.api.cmk.registry.auth.v1.Service/ListAuths"
 	Service_RemoveAuth_FullMethodName = "/kms.api.cmk.registry.auth.v1.Service/RemoveAuth"
 )
 
@@ -31,7 +31,7 @@ const (
 type ServiceClient interface {
 	ApplyAuth(ctx context.Context, in *ApplyAuthRequest, opts ...grpc.CallOption) (*ApplyAuthResponse, error)
 	GetAuth(ctx context.Context, in *GetAuthRequest, opts ...grpc.CallOption) (*GetAuthResponse, error)
-	ListAuth(ctx context.Context, in *ListAuthRequest, opts ...grpc.CallOption) (*ListAuthResponse, error)
+	ListAuths(ctx context.Context, in *ListAuthsRequest, opts ...grpc.CallOption) (*ListAuthsResponse, error)
 	RemoveAuth(ctx context.Context, in *RemoveAuthRequest, opts ...grpc.CallOption) (*RemoveAuthResponse, error)
 }
 
@@ -63,10 +63,10 @@ func (c *serviceClient) GetAuth(ctx context.Context, in *GetAuthRequest, opts ..
 	return out, nil
 }
 
-func (c *serviceClient) ListAuth(ctx context.Context, in *ListAuthRequest, opts ...grpc.CallOption) (*ListAuthResponse, error) {
+func (c *serviceClient) ListAuths(ctx context.Context, in *ListAuthsRequest, opts ...grpc.CallOption) (*ListAuthsResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(ListAuthResponse)
-	err := c.cc.Invoke(ctx, Service_ListAuth_FullMethodName, in, out, cOpts...)
+	out := new(ListAuthsResponse)
+	err := c.cc.Invoke(ctx, Service_ListAuths_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -89,7 +89,7 @@ func (c *serviceClient) RemoveAuth(ctx context.Context, in *RemoveAuthRequest, o
 type ServiceServer interface {
 	ApplyAuth(context.Context, *ApplyAuthRequest) (*ApplyAuthResponse, error)
 	GetAuth(context.Context, *GetAuthRequest) (*GetAuthResponse, error)
-	ListAuth(context.Context, *ListAuthRequest) (*ListAuthResponse, error)
+	ListAuths(context.Context, *ListAuthsRequest) (*ListAuthsResponse, error)
 	RemoveAuth(context.Context, *RemoveAuthRequest) (*RemoveAuthResponse, error)
 	mustEmbedUnimplementedServiceServer()
 }
@@ -107,8 +107,8 @@ func (UnimplementedServiceServer) ApplyAuth(context.Context, *ApplyAuthRequest) 
 func (UnimplementedServiceServer) GetAuth(context.Context, *GetAuthRequest) (*GetAuthResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetAuth not implemented")
 }
-func (UnimplementedServiceServer) ListAuth(context.Context, *ListAuthRequest) (*ListAuthResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method ListAuth not implemented")
+func (UnimplementedServiceServer) ListAuths(context.Context, *ListAuthsRequest) (*ListAuthsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListAuths not implemented")
 }
 func (UnimplementedServiceServer) RemoveAuth(context.Context, *RemoveAuthRequest) (*RemoveAuthResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method RemoveAuth not implemented")
@@ -170,20 +170,20 @@ func _Service_GetAuth_Handler(srv interface{}, ctx context.Context, dec func(int
 	return interceptor(ctx, in, info, handler)
 }
 
-func _Service_ListAuth_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(ListAuthRequest)
+func _Service_ListAuths_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListAuthsRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(ServiceServer).ListAuth(ctx, in)
+		return srv.(ServiceServer).ListAuths(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: Service_ListAuth_FullMethodName,
+		FullMethod: Service_ListAuths_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(ServiceServer).ListAuth(ctx, req.(*ListAuthRequest))
+		return srv.(ServiceServer).ListAuths(ctx, req.(*ListAuthsRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -222,8 +222,8 @@ var Service_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _Service_GetAuth_Handler,
 		},
 		{
-			MethodName: "ListAuth",
-			Handler:    _Service_ListAuth_Handler,
+			MethodName: "ListAuths",
+			Handler:    _Service_ListAuths_Handler,
 		},
 		{
 			MethodName: "RemoveAuth",

--- a/proto/kms/api/cmk/registry/auth/v1/auth_grpc.pb.go
+++ b/proto/kms/api/cmk/registry/auth/v1/auth_grpc.pb.go
@@ -21,6 +21,7 @@ const _ = grpc.SupportPackageIsVersion9
 const (
 	Service_ApplyAuth_FullMethodName  = "/kms.api.cmk.registry.auth.v1.Service/ApplyAuth"
 	Service_GetAuth_FullMethodName    = "/kms.api.cmk.registry.auth.v1.Service/GetAuth"
+	Service_ListAuth_FullMethodName   = "/kms.api.cmk.registry.auth.v1.Service/ListAuth"
 	Service_RemoveAuth_FullMethodName = "/kms.api.cmk.registry.auth.v1.Service/RemoveAuth"
 )
 
@@ -30,6 +31,7 @@ const (
 type ServiceClient interface {
 	ApplyAuth(ctx context.Context, in *ApplyAuthRequest, opts ...grpc.CallOption) (*ApplyAuthResponse, error)
 	GetAuth(ctx context.Context, in *GetAuthRequest, opts ...grpc.CallOption) (*GetAuthResponse, error)
+	ListAuth(ctx context.Context, in *ListAuthRequest, opts ...grpc.CallOption) (*ListAuthResponse, error)
 	RemoveAuth(ctx context.Context, in *RemoveAuthRequest, opts ...grpc.CallOption) (*RemoveAuthResponse, error)
 }
 
@@ -61,6 +63,16 @@ func (c *serviceClient) GetAuth(ctx context.Context, in *GetAuthRequest, opts ..
 	return out, nil
 }
 
+func (c *serviceClient) ListAuth(ctx context.Context, in *ListAuthRequest, opts ...grpc.CallOption) (*ListAuthResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListAuthResponse)
+	err := c.cc.Invoke(ctx, Service_ListAuth_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *serviceClient) RemoveAuth(ctx context.Context, in *RemoveAuthRequest, opts ...grpc.CallOption) (*RemoveAuthResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(RemoveAuthResponse)
@@ -77,6 +89,7 @@ func (c *serviceClient) RemoveAuth(ctx context.Context, in *RemoveAuthRequest, o
 type ServiceServer interface {
 	ApplyAuth(context.Context, *ApplyAuthRequest) (*ApplyAuthResponse, error)
 	GetAuth(context.Context, *GetAuthRequest) (*GetAuthResponse, error)
+	ListAuth(context.Context, *ListAuthRequest) (*ListAuthResponse, error)
 	RemoveAuth(context.Context, *RemoveAuthRequest) (*RemoveAuthResponse, error)
 	mustEmbedUnimplementedServiceServer()
 }
@@ -93,6 +106,9 @@ func (UnimplementedServiceServer) ApplyAuth(context.Context, *ApplyAuthRequest) 
 }
 func (UnimplementedServiceServer) GetAuth(context.Context, *GetAuthRequest) (*GetAuthResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetAuth not implemented")
+}
+func (UnimplementedServiceServer) ListAuth(context.Context, *ListAuthRequest) (*ListAuthResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListAuth not implemented")
 }
 func (UnimplementedServiceServer) RemoveAuth(context.Context, *RemoveAuthRequest) (*RemoveAuthResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method RemoveAuth not implemented")
@@ -154,6 +170,24 @@ func _Service_GetAuth_Handler(srv interface{}, ctx context.Context, dec func(int
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Service_ListAuth_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListAuthRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ServiceServer).ListAuth(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Service_ListAuth_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ServiceServer).ListAuth(ctx, req.(*ListAuthRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _Service_RemoveAuth_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(RemoveAuthRequest)
 	if err := dec(in); err != nil {
@@ -186,6 +220,10 @@ var Service_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetAuth",
 			Handler:    _Service_GetAuth_Handler,
+		},
+		{
+			MethodName: "ListAuth",
+			Handler:    _Service_ListAuth_Handler,
 		},
 		{
 			MethodName: "RemoveAuth",


### PR DESCRIPTION
<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       fix
- description:   add external id and list rpc in auth service

Following the conventional commits: https://www.conventionalcommits.org
-->

**What this PR does / why we need it**:
There are two changes concerning the auth service:
- An ID is added. This enables having multiple auths (which can be of the same type but different versions) for the same tenant. The ID is set externally, same as for tenants and systems.
- A list RPC is added. This enables the caller to list auths by their tenant ID (additional filters e.g. `status` can be added in the future).

Additionally, a missing `ACTION_REMOVE_AUTH` is added.
